### PR TITLE
Update script.swift for Xcode 11 compiler

### DIFF
--- a/Sources/BitcoinKit/Scripts/Script.swift
+++ b/Sources/BitcoinKit/Scripts/Script.swift
@@ -474,8 +474,10 @@ extension Script {
     // Standard Transaction to Bitcoin address (pay-to-pubkey-hash)
     // scriptPubKey: OP_DUP OP_HASH160 <pubKeyHash> OP_EQUALVERIFY OP_CHECKSIG
     public static func buildPublicKeyHashOut(pubKeyHash: Data) -> Data {
-        let tmp: Data = Data() + OpCode.OP_DUP + OpCode.OP_HASH160 + UInt8(pubKeyHash.count) + pubKeyHash + OpCode.OP_EQUALVERIFY
-        return tmp + OpCode.OP_CHECKSIG
+        let tmp: Data = Data() + OpCode.OP_DUP + OpCode.OP_HASH160 + UInt8(pubKeyHash.count)
+        let secondTmp = pubKeyHash + OpCode.OP_EQUALVERIFY
+        
+        return tmp + secondTmp + OpCode.OP_CHECKSIG
     }
 
     public static func buildPublicKeyUnlockingScript(signature: Data, pubkey: PublicKey, hashType: SighashType) -> Data {


### PR DESCRIPTION
When building with Xcode 11 the compiler throws an error: 
The compiler is unable to type-check this expression in reasonable time; try breaking up the expression into distinct sub-expressions